### PR TITLE
debian: patches: add patch and update series

### DIFF
--- a/debian/patches/add-getting-led-configuration-from-dts.patch
+++ b/debian/patches/add-getting-led-configuration-from-dts.patch
@@ -1,0 +1,121 @@
+From d16a2f7a2fed05672213369a606ca6a942f10213 Mon Sep 17 00:00:00 2001
+From: RadxaMitchell <machuang@radxa.com>
+Date: Mon, 15 Jul 2024 19:39:47 +0800
+Subject: [PATCH] add getting led configuration from dts
+
+This patch is from istoreos/istoreos@52313c5
+Author: jjm2473 <jjm2473@gmail.com>
+
+Signed-off-by: RadxaMitchell <machuang@radxa.com>
+---
+ src/r8125.h   |  5 +++++
+ src/r8125_n.c | 55 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 60 insertions(+)
+
+diff --git a/src/r8125.h b/src/r8125.h
+index 0d7474f..a531068 100755
+--- a/src/r8125.h
++++ b/src/r8125.h
+@@ -1273,6 +1273,7 @@ enum RTL8125_registers {
+         CounterAddrLow      = 0x10,
+         CounterAddrHigh     = 0x14,
+         CustomLED       = 0x18,
++        LEDSEL0         = 0x18,
+         TxDescStartAddrLow  = 0x20,
+         TxDescStartAddrHigh = 0x24,
+         TxHDescStartAddrLow = 0x28,
+@@ -1309,7 +1310,11 @@ enum RTL8125_registers {
+         INT_CFG1_8125   = 0x7A,
+         EPHY_RXER_NUM   = 0x7C,
+         EPHYAR          = 0x80,
++        LEDSEL2         = 0x84,
++        LEDSEL1         = 0x86,
+         TimeInt2        = 0x8C,
++        LEDFEATURE      = 0x94,
++        LEDSEL3         = 0x96,
+         OCPDR           = 0xB0,
+         MACOCP          = 0xB0,
+         OCPAR           = 0xB4,
+diff --git a/src/r8125_n.c b/src/r8125_n.c
+index 90a8707..766bb21 100755
+--- a/src/r8125_n.c
++++ b/src/r8125_n.c
+@@ -46,6 +46,7 @@
+ #include <linux/if_vlan.h>
+ #include <linux/crc32.h>
+ #include <linux/interrupt.h>
++#include <linux/of.h>
+ #include <linux/in.h>
+ #include <linux/ip.h>
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,22)
+@@ -13626,6 +13627,58 @@ rtl8125_setup_mqs_reg(struct rtl8125_private *tp)
+                 tp->imr_reg[i] = (u16)(IMR1_8125 + (i - 1) * 4);
+ }
+ 
++/*
++ * Refer to RTL8125 datasheet 5.Customizable LED Configuration
++ * Register Name	IO Address
++ * LEDSEL0		    0x18
++ * LEDSEL1		    0x86
++ * LEDSEL2		    0x84
++ * LEDSEL3		    0x96
++ * LEDFEATURE		0x94
++ *
++ * LEDSEL Bit[]	Description
++ * Bit0			Link10M
++ * Bit1			Link100M
++ * Bit3			Link1000M
++ * Bit5			Link2.5G
++ * Bit9			ACT
++ * Bit10		    preboot enable
++ * Bit11		    lp enable
++ * Bit12		    active low/high
++ *
++ * LEDFEATURE		Description
++ * Bit0			LED Table V1/V2
++ * Bit1~3		    Reserved
++ * Bit4~5		    LED Blinking Duty Cycle	12.5%/ 25%/ 50%/ 75%
++ * Bit6~7		    LED Blinking Freq. 240ms/160ms/80ms/Link-Speed-Dependent
++ */
++static int
++rtl8125_led_configuration(struct rtl8125_private *tp)
++{
++        const int led_regs[] = { LEDSEL0, LEDSEL1, LEDSEL2, LEDSEL3 }; /* LEDSEL 0-3 */
++        u16 led_data[4];
++        u8 led_feature;
++        int ret, i;
++
++        ret = of_property_read_u16_array(tp->pci_dev->dev.of_node,
++                                  "realtek,led-data", led_data, 4);
++
++        if (!ret) {
++                for (i = 0; i < 4; i++) {
++                        RTL_W16(tp, led_regs[i], led_data[i]);
++                        msleep(1);
++                }
++        }
++
++        ret = of_property_read_u8(tp->pci_dev->dev.of_node,
++                                  "realtek,led-feature", &led_feature);
++
++        if (!ret) {
++                RTL_W8(tp, LEDFEATURE, led_feature);
++        }
++        return 0;
++}
++
+ static void
+ rtl8125_init_software_variable(struct net_device *dev)
+ {
+@@ -14262,6 +14315,8 @@ rtl8125_init_software_variable(struct net_device *dev)
+ 
+         tp->NicCustLedValue = RTL_R16(tp, CustomLED);
+ 
++        rtl8125_led_configuration(tp);
++
+         tp->wol_opts = rtl8125_get_hw_wol(tp);
+         tp->wol_enabled = (tp->wol_opts) ? WOL_ENABLED : WOL_DISABLED;
+ 
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ linux5.12.patch
 linux-6.9.patch
 improve_network_stability.patch
 fix-fall-through.patch
+add-getting-led-configuration-from-dts.patch


### PR DESCRIPTION
Add patch to r8125 driver to get led light configurations from dts and adding patch names to series. This patch is from istoreos/istoreos@52313c5
Author: jjm2473 <jjm2473@gmail.com>